### PR TITLE
Drop Ruby 3.2 support, bump to 0.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           - '4.0'
           - '3.4'
           - '3.3'
-          - '3.2'
         include:
           - ruby: '4.0'
             coverage: 'true'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   NewCops: enable
   SuggestExtensions: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.13.0 (2026-05-11)
+- [Breaking] Dropped Ruby 3.2 support. Minimum required Ruby version is now 3.3.
+
 ## 0.12.0 (2025-11-12)
 - [Feature] **HTML to Markdown Reverse Converter** — Added support for converting HTML content to markdown format.
   - Enables processing of HTML documentation sources

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    llm-docs-builder (0.12.0)
+    llm-docs-builder (0.13.0)
       nokogiri (~> 1.17)
       zeitwerk (~> 2.6)
 
@@ -93,4 +93,4 @@ DEPENDENCIES
   yard-lint
 
 BUNDLED WITH
-   2.7.2
+   2.6.9

--- a/lib/llm_docs_builder/version.rb
+++ b/lib/llm_docs_builder/version.rb
@@ -2,5 +2,5 @@
 
 module LlmDocsBuilder
   # Current version of the LlmDocsBuilder gem
-  VERSION = '0.12.0'
+  VERSION = '0.13.0'
 end

--- a/llm-docs-builder.gemspec
+++ b/llm-docs-builder.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.homepage = 'https://github.com/mensfeld/llm-docs-builder'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 3.2'
+  spec.required_ruby_version = '>= 3.3'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   spec.metadata['homepage_uri'] = spec.homepage


### PR DESCRIPTION
## Summary
- Drop Ruby 3.2 from the CI test matrix
- Raise `required_ruby_version` to `>= 3.3` in the gemspec
- Update RuboCop `TargetRubyVersion` to 3.3
- Bump version to 0.13.0 (breaking change)
- Update CHANGELOG.md

Fixes the CI failure in #110 where `parallel 2.1.0` requires Ruby >= 3.3.

## Test plan
- [ ] CI passes on Ruby 3.3, 3.4, and 4.0
- [ ] Merge #110 (lock file maintenance) after this lands