### PR TITLE
Enhancement: Add Ruby warning category opt-in to test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- [Enhancement] Add Ruby warning category opt-in to test helpers
+
 ## 0.13.0 (2026-05-11)
 - [Breaking] Dropped Ruby 3.2 support. Minimum required Ruby version is now 3.3.
 - [Fix] **Heading Nesting in Normalize Mode** — Fixed `normalize_headings` producing incorrect heading levels when same-level headings are nested under a parent.

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ group :development do
   gem 'pry'
   gem 'yard-lint'
 end
+
+group :test do
+  gem 'warning'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    warning (1.6.0)
     yard (0.9.43)
     yard-lint (1.5.1)
       yard (~> 0.9)
@@ -90,6 +91,7 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 1.0)
   simplecov (~> 0.21)
+  warning
   yard-lint
 
 BUNDLED WITH

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,6 @@ if Warning.respond_to?(:categories)
   (Warning.categories - %i[experimental]).each do |cat|
     Warning[cat] = true
   end
-else
-  Warning[:deprecated] = true
-  Warning[:performance] = true if RUBY_VERSION >= '3.3'
 end
 
 Warning.process do |warning|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
-Warning[:performance] = true if RUBY_VERSION >= '3.3'
-Warning[:deprecated] = true
+require 'warning'
+
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
   (Warning.categories - %i[experimental]).each do |cat|
     Warning[cat] = true
   end
+else
+  Warning[:deprecated] = true
+  Warning[:performance] = true if RUBY_VERSION >= '3.3'
 end
-
-require 'warning'
 
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,9 @@ Warning[:deprecated] = true
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
-  (Warning.categories - %i[experimental]).each { |cat| Warning[cat] = true }
+  (Warning.categories - %i[experimental]).each do |cat|
+    Warning[cat] = true
+  end
 end
 
 require 'warning'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,6 @@ end
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)
   next if warning.include?('_spec')
-  next if warning.include?('previous definition of')
-  next if warning.include?('method redefined')
   next if warning.include?('vendor/')
   next if warning.include?('bundle/')
   next if warning.include?('.bundle/')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ Warning[:deprecated] = true
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
-  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+  (Warning.categories - %i[experimental]).each { |cat| Warning[cat] = true }
 end
 
 require 'warning'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+Warning[:performance] = true if RUBY_VERSION >= '3.3'
+Warning[:deprecated] = true
+$VERBOSE = true
+
+if Warning.respond_to?(:categories)
+  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+end
+
+require 'warning'
+
+Warning.process do |warning|
+  next unless warning.include?(Dir.pwd)
+  next if warning.include?('_spec')
+  next if warning.include?('previous definition of')
+  next if warning.include?('method redefined')
+  next if warning.include?('vendor/')
+  next if warning.include?('bundle/')
+  next if warning.include?('.bundle/')
+  raise "Warning in your code: #{warning}"
+end
+
 require 'bundler/setup'
 require 'llm_docs_builder'
 require 'simplecov'


### PR DESCRIPTION
## Summary

- Adds `gem 'warning'` to the `:test` group in `Gemfile`
- Configures Ruby warning categories (`Warning[:deprecated]`, `Warning[:performance]`) at the top of `spec/spec_helper.rb`
- Uses `Warning.process` to raise on any warnings originating from project code (excluding specs, vendored/bundled gems, and known noise patterns)
- Updates `Gemfile.lock` with `warning 1.6.0`
- Adds CHANGELOG entry under `[Unreleased]`

## Test plan

- [ ] Run `bundle install` to confirm `warning` gem resolves cleanly
- [ ] Run the test suite (`bundle exec rspec`) to confirm no existing code triggers new warning errors