### PR TITLE
Enable new yard-lint 1.10 documentation linters

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -62,6 +62,26 @@ Documentation/BlankLineBeforeDefinition:
     SingleBlankLine: true
     OrphanedDocs: true
 
+Documentation/DuplicateNamespaceComment:
+  Description: Detects namespaces documented with a YARD comment in more than one file.
+  Enabled: true
+  Severity: error
+
+Documentation/UnderfilledLines:
+  Description: Detects documentation prose that wraps too early and wastes horizontal space.
+  Enabled: true
+  Severity: error
+  # Aligned with RuboCop's Layout/LineLength so documentation prose wraps to the same
+  # width as code.
+  MaxLength: 120
+
+Documentation/LineLength:
+  Description: Detects documentation lines that exceed the maximum length.
+  Enabled: true
+  Severity: error
+  # Aligned with RuboCop's Layout/LineLength.
+  MaxLength: 120
+
 # Tags validators
 Tags/Order:
   Description: Enforces consistent ordering of YARD tags.
@@ -142,7 +162,7 @@ Tags/OptionTags:
 Tags/ExampleSyntax:
   Description: Validates Ruby syntax in @example tags.
   Enabled: true
-  Severity: warning
+  Severity: error
 
 Tags/RedundantParamDescription:
   Description: Detects meaningless parameter descriptions that add no value.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,8 +68,8 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     warning (1.6.0)
-    yard (0.9.44)
-    yard-lint (1.9.0)
+    yard (0.9.45)
+    yard-lint (1.10.1)
       yard (~> 0.9)
       zeitwerk (~> 2.6)
     zeitwerk (2.8.2)
@@ -89,4 +89,4 @@ DEPENDENCIES
   yard-lint
 
 BUNDLED WITH
-   2.6.9
+  4.0.17

--- a/lib/llm_docs_builder.rb
+++ b/lib/llm_docs_builder.rb
@@ -13,9 +13,8 @@ loader.setup
 
 # Build and optimize documentation for LLMs
 #
-# This gem provides tools for generating llms.txt files and transforming markdown
-# documentation to be AI-friendly. It can reduce token consumption by 67-95% while
-# preserving essential documentation content.
+# This gem provides tools for generating llms.txt files and transforming markdown documentation to be AI-friendly. It
+# can reduce token consumption by 67-95% while preserving essential documentation content.
 #
 # @api public
 module LlmDocsBuilder

--- a/lib/llm_docs_builder/cli.rb
+++ b/lib/llm_docs_builder/cli.rb
@@ -129,8 +129,7 @@ module LlmDocsBuilder
 
     # Generate llms.txt from documentation directory or file
     #
-    # Loads configuration, merges with CLI options, generates llms.txt content,
-    # and optionally validates the output.
+    # Loads configuration, merges with CLI options, generates llms.txt content, and optionally validates the output.
     #
     # @param options [Hash] command options from parse_options
     # @option options [String] :config path to config file

--- a/lib/llm_docs_builder/generator.rb
+++ b/lib/llm_docs_builder/generator.rb
@@ -34,8 +34,7 @@ module LlmDocsBuilder
 
     # Generate llms.txt content from documentation
     #
-    # Scans documentation files, extracts metadata, prioritizes them, and builds a formatted
-    # llms.txt file.
+    # Scans documentation files, extracts metadata, prioritizes them, and builds a formatted llms.txt file.
     #
     # @return [String] generated llms.txt content
     def generate

--- a/lib/llm_docs_builder/html_detector.rb
+++ b/lib/llm_docs_builder/html_detector.rb
@@ -14,8 +14,7 @@ module LlmDocsBuilder
       full_html_document?(content)
     end
 
-    # Prepare a snippet of content for HTML detection by removing leading whitespace
-    # and build metadata comments.
+    # Prepare a snippet of content for HTML detection by removing leading whitespace and build metadata comments.
     #
     # @param content [String]
     # @return [String, nil]

--- a/lib/llm_docs_builder/html_to_markdown/figure_code_block_renderer.rb
+++ b/lib/llm_docs_builder/html_to_markdown/figure_code_block_renderer.rb
@@ -3,9 +3,8 @@
 module LlmDocsBuilder
   # Provides HTML to Markdown conversion functionality
   #
-  # This module contains specialized renderers for converting HTML elements
-  # to Markdown format, with support for complex structures like tables,
-  # figures, and syntax-highlighted code blocks.
+  # This module contains specialized renderers for converting HTML elements to Markdown format, with support for complex
+  # structures like tables, figures, and syntax-highlighted code blocks.
   #
   # @api private
   module HtmlToMarkdown

--- a/lib/llm_docs_builder/html_to_markdown_converter.rb
+++ b/lib/llm_docs_builder/html_to_markdown_converter.rb
@@ -644,11 +644,9 @@ module LlmDocsBuilder
 
     # Compute effective heading level adjusted for section nesting
     #
-    # When HTML uses nested <section> elements with same-level headings,
-    # the inner headings should receive deeper markdown levels. The offset
-    # is calculated as the difference between the actual section ancestor
-    # count and the expected count for that heading tag (h1 expects 0
-    # sections, h2 expects 1, etc.), capped at heading level 6.
+    # When HTML uses nested <section> elements with same-level headings, the inner headings should receive deeper
+    # markdown levels. The offset is calculated as the difference between the actual section ancestor count and the
+    # expected count for that heading tag (h1 expects 0 sections, h2 expects 1, etc.), capped at heading level 6.
     #
     # @param element [Nokogiri::XML::Element] heading element
     # @param base_level [Integer] HTML heading level (1-6)

--- a/lib/llm_docs_builder/output_formatter.rb
+++ b/lib/llm_docs_builder/output_formatter.rb
@@ -3,8 +3,7 @@
 module LlmDocsBuilder
   # Formats output for CLI display
   #
-  # Provides formatting utilities for displaying comparison results,
-  # byte sizes, and numbers in a user-friendly way.
+  # Provides formatting utilities for displaying comparison results, byte sizes, and numbers in a user-friendly way.
   #
   # @api private
   class OutputFormatter

--- a/lib/llm_docs_builder/parser.rb
+++ b/lib/llm_docs_builder/parser.rb
@@ -3,9 +3,8 @@
 module LlmDocsBuilder
   # Parses llms.txt files into structured data
   #
-  # Reads and parses llms.txt files according to the llms.txt specification,
-  # extracting the title, description, and structured sections (Documentation,
-  # Examples, Optional) with their links.
+  # Reads and parses llms.txt files according to the llms.txt specification, extracting the title, description, and
+  # structured sections (Documentation, Examples, Optional) with their links.
   #
   # @example Parse an llms.txt file
   #   parser = LlmDocsBuilder::Parser.new('llms.txt')
@@ -109,8 +108,7 @@ module LlmDocsBuilder
 
   # Represents parsed llms.txt content with structured access to sections
   #
-  # Provides convenient access to parsed llms.txt sections including title,
-  # description, and link collections.
+  # Provides convenient access to parsed llms.txt sections including title, description, and link collections.
   #
   # @example Access parsed content
   #   parsed.title              # => "My Project"

--- a/lib/llm_docs_builder/text_compressor.rb
+++ b/lib/llm_docs_builder/text_compressor.rb
@@ -3,9 +3,8 @@
 module LlmDocsBuilder
   # Advanced text compression techniques for reducing token count
   #
-  # Provides more aggressive text compression methods including stopword removal,
-  # duplicate content detection, and sentence deduplication. These methods are more
-  # aggressive than basic markdown cleanup and should be used carefully.
+  # Provides more aggressive text compression methods including stopword removal, duplicate content detection, and
+  # sentence deduplication. These methods are more aggressive than basic markdown cleanup and should be used carefully.
   #
   # @example Basic usage
   #   compressor = LlmDocsBuilder::TextCompressor.new

--- a/lib/llm_docs_builder/token_estimator.rb
+++ b/lib/llm_docs_builder/token_estimator.rb
@@ -3,9 +3,8 @@
 module LlmDocsBuilder
   # Estimates token count for text content using character-based approximation
   #
-  # Provides token estimation without requiring external tokenizer dependencies.
-  # Uses the common heuristic that ~4 characters equals 1 token for English text,
-  # which works reasonably well for documentation and markdown content.
+  # Provides token estimation without requiring external tokenizer dependencies. Uses the common heuristic that ~4
+  # characters equals 1 token for English text, which works reasonably well for documentation and markdown content.
   #
   # @example Basic usage
   #   estimator = LlmDocsBuilder::TokenEstimator.new

--- a/lib/llm_docs_builder/transformers/base_transformer.rb
+++ b/lib/llm_docs_builder/transformers/base_transformer.rb
@@ -3,9 +3,8 @@
 module LlmDocsBuilder
   # Provides content transformation functionality
   #
-  # This module contains specialized transformers for modifying markdown content,
-  # including cleanup operations, link processing, heading normalization, and
-  # content enhancement for AI consumption.
+  # This module contains specialized transformers for modifying markdown content, including cleanup operations, link
+  # processing, heading normalization, and content enhancement for AI consumption.
   #
   # @api private
   module Transformers

--- a/lib/llm_docs_builder/transformers/heading_transformer.rb
+++ b/lib/llm_docs_builder/transformers/heading_transformer.rb
@@ -4,9 +4,8 @@ module LlmDocsBuilder
   module Transformers
     # Normalizes headings to include hierarchical context
     #
-    # Transforms markdown headings to include parent context, making each section
-    # self-contained for RAG systems. This is particularly useful when documents
-    # are chunked and retrieved independently.
+    # Transforms markdown headings to include parent context, making each section self-contained for RAG systems. This
+    # is particularly useful when documents are chunked and retrieved independently.
     #
     # @example Basic heading normalization
     #   # Configuration

--- a/lib/llm_docs_builder/transformers/link_transformer.rb
+++ b/lib/llm_docs_builder/transformers/link_transformer.rb
@@ -4,8 +4,7 @@ module LlmDocsBuilder
   module Transformers
     # Transformer for link-related operations
     #
-    # Handles expansion of relative links to absolute URLs and
-    # conversion of HTML URLs to markdown format.
+    # Handles expansion of relative links to absolute URLs and conversion of HTML URLs to markdown format.
     #
     # @api public
     class LinkTransformer

--- a/lib/llm_docs_builder/transformers/whitespace_transformer.rb
+++ b/lib/llm_docs_builder/transformers/whitespace_transformer.rb
@@ -4,8 +4,7 @@ module LlmDocsBuilder
   module Transformers
     # Transformer for whitespace normalization
     #
-    # Reduces excessive blank lines and trailing whitespace to make
-    # content more compact for LLM consumption.
+    # Reduces excessive blank lines and trailing whitespace to make content more compact for LLM consumption.
     #
     # @api public
     class WhitespaceTransformer

--- a/lib/llm_docs_builder/validator.rb
+++ b/lib/llm_docs_builder/validator.rb
@@ -56,8 +56,7 @@ module LlmDocsBuilder
 
     # Validate content and return result
     #
-    # Runs all validation checks, populates {#errors} array, and returns whether
-    # the content is valid.
+    # Runs all validation checks, populates {#errors} array, and returns whether the content is valid.
     #
     # @return [Boolean] true if content is valid, false otherwise
     def validate!


### PR DESCRIPTION
Updates yard-lint to 1.10.1 and enables the new documentation linters (`DuplicateNamespaceComment`, `UnderfilledLines` as errors; `ExampleSyntax` to error), with `MaxLength` aligned to this project's RuboCop `Layout/LineLength`. Fixes every offense they surface. `bundle exec yard-lint lib/` reports `No offenses found`.