### PR TITLE
Standardize Tags/Order to the expanded EnforcedOrder

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -98,9 +98,15 @@ Tags/Order:
   EnforcedOrder:
   - param
   - option
+  - yield
+  - yieldparam
+  - yieldreturn
   - return
   - raise
+  - see
   - example
+  - note
+  - todo
 
 Tags/InvalidTypes:
   Description: Validates type definitions in @param, @return, @option tags.


### PR DESCRIPTION
Adopts the expanded `Tags/Order` `EnforcedOrder` (`param, option, yield*, return, raise, see, example, note, todo`) as the ecosystem standard, and reorders the affected docstrings to match. `bundle exec yard-lint lib/` reports `No offenses found`.