### PR TITLE
Backfill missing gemspec metadata

### DIFF
--- a/llm-docs-builder.gemspec
+++ b/llm-docs-builder.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/mensfeld/llm-docs-builder'
   spec.metadata['changelog_uri'] = 'https://github.com/mensfeld/llm-docs-builder/blob/master/CHANGELOG.md'
   spec.metadata['documentation_uri'] = 'https://github.com/mensfeld/llm-docs-builder'
+  spec.metadata['bug_tracker_uri'] = 'https://github.com/mensfeld/llm-docs-builder/issues'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|test)/}) }


### PR DESCRIPTION
Adds the `metadata` keys this gem was missing relative to the rest of the fleet (per the gemspec audit): **bug_tracker_uri **

- URIs point at the standard GitHub locations (`/issues` for bug tracker, repo URL for docs/homepage), matching the repo's existing quote/interpolation style.
- Improves the rubygems.org sidebar links.

Gemspec loads cleanly (`Gem::Specification.load`); no other changes.