### PR TITLE
Fix LinkTransformer corrupting mailto:/tel:/ftp: links (#165); release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+
+## 1.0.0 (2026-08-24)
+- [Fix] **Link Expansion Corrupts Non-HTTP URI Schemes** — `LinkTransformer#expand_relative_links` no longer rewrites `mailto:`, `tel:`, and `ftp:` links into dead `https://...` URLs when `base_url` is set (#165).
+  - Any link whose scheme is in the known absolute-scheme list (`http`, `https`, `mailto`, `ftp`, `tel`) is now left untouched, matching `HtmlToMarkdownConverter`'s `SAFE_URI_SCHEMES`.
+  - Relative links (e.g. `./guide.md`) continue to expand as before.
 - [Enhancement] Add Ruby warning category opt-in to test helpers
 
 ## 0.13.0 (2026-05-11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    llm-docs-builder (0.13.0)
+    llm-docs-builder (1.0.0)
       nokogiri (~> 1.17)
       zeitwerk (~> 2.6)
 

--- a/lib/llm_docs_builder/transformers/link_transformer.rb
+++ b/lib/llm_docs_builder/transformers/link_transformer.rb
@@ -29,6 +29,10 @@ module LlmDocsBuilder
 
       private
 
+      # URI schemes that must never be treated as relative paths when expanding
+      # links with a base URL (kept in sync with the converter's safe schemes)
+      ABSOLUTE_URL_SCHEMES = %w[http https mailto ftp tel].freeze
+
       # Expand relative links to absolute URLs
       #
       # @param content [String] markdown content
@@ -39,7 +43,7 @@ module LlmDocsBuilder
           text = ::Regexp.last_match(1)
           url = ::Regexp.last_match(2)
 
-          if url.start_with?('http://', 'https://', '//', '#')
+          if url.start_with?('http://', 'https://', '//', '#') || absolute_url_scheme?(url)
             match
           else
             clean_url = url.gsub(%r{^\./}, '')
@@ -47,6 +51,15 @@ module LlmDocsBuilder
             "[#{text}](#{expanded_url})"
           end
         end
+      end
+
+      # Check whether a link target uses a known absolute URI scheme
+      #
+      # @param url [String] link target
+      # @return [Boolean] true when the target already carries its own scheme
+      def absolute_url_scheme?(url)
+        scheme = url.split(':', 2).first.to_s
+        ABSOLUTE_URL_SCHEMES.include?(scheme)
       end
 
       # Convert HTML URLs to markdown format

--- a/lib/llm_docs_builder/version.rb
+++ b/lib/llm_docs_builder/version.rb
@@ -2,5 +2,5 @@
 
 module LlmDocsBuilder
   # Current version of the LlmDocsBuilder gem
-  VERSION = '0.13.0'
+  VERSION = '1.0.0'
 end

--- a/spec/transformers/link_transformer_spec.rb
+++ b/spec/transformers/link_transformer_spec.rb
@@ -41,6 +41,34 @@ RSpec.describe LlmDocsBuilder::Transformers::LinkTransformer do
 
         expect(result).to eq('[Protocol-relative](//cdn.example.com/file.js)')
       end
+
+      it 'preserves mailto: links' do
+        content = 'Contact [support](mailto:help@example.com)'
+        result = transformer.transform(content, base_url: 'https://example.com/docs')
+
+        expect(result).to eq('Contact [support](mailto:help@example.com)')
+      end
+
+      it 'preserves tel: links' do
+        content = 'Call [us](tel:+1234567890)'
+        result = transformer.transform(content, base_url: 'https://example.com/docs')
+
+        expect(result).to eq('Call [us](tel:+1234567890)')
+      end
+
+      it 'preserves ftp: links' do
+        content = 'Download [file](ftp://example.com/file.zip)'
+        result = transformer.transform(content, base_url: 'https://example.com/docs')
+
+        expect(result).to eq('Download [file](ftp://example.com/file.zip)')
+      end
+
+      it 'still expands relative links when non-http schemes are present' do
+        content = 'See [guide](./guide.md) or [mail](mailto:a@b.com)'
+        result = transformer.transform(content, base_url: 'https://example.com/docs')
+
+        expect(result).to eq('See [guide](https://example.com/docs/guide.md) or [mail](mailto:a@b.com)')
+      end
     end
 
     context 'with convert_urls option' do


### PR DESCRIPTION
## Summary

Fixes #165.

`LinkTransformer#expand_relative_links` corrupted `mailto:`, `tel:`, and `ftp:` links into dead `https://…` URLs whenever `base_url` was set:

```
Contact [support](mailto:help@example.com)
  → Contact [support](https://example.com/docs/mailto:help@example.com)
```

The guard only exempted `http://`, `https://`, `//`, and `#` prefixes, so any other absolute URI scheme fell through to `File.join(base_url, url)`. This is especially bad for an LLM-facing pipeline: the model receives a plausible-looking absolute URL that 404s. These schemes are expected input — `HtmlToMarkdownConverter` explicitly whitelists `mailto`, `ftp`, and `tel` in its `SAFE_URI_SCHEMES`.

## Fix

Added an `ABSOLUTE_URL_SCHEMES` list (`http https mailto ftp tel`, kept in sync with the converter's safe schemes) and an `absolute_url_scheme?` guard. Any link that already carries one of these schemes is left untouched; relative links (`./guide.md`) still expand as before.

## Verification

- Reproduced on stock master before touching source.
- Post-fix: `mailto:` / `tel:` / `ftp:` pass through untouched; `./guide.md` still expands to `https://example.com/docs/guide.md`; `#anchor`, `//protocol-relative`, and existing absolute URLs unaffected.
- Added 4 regression specs → `spec/transformers/link_transformer_spec.rb` now 25/25 green.
- Full suite: 454 examples, 2 failures — both in `generator_spec.rb`, confirmed **pre-existing on clean HEAD** (unrelated filesystem-path tests). This change adds +4 examples, +0 failures.

## Release

Bumps version to **1.0.0** and adds a CHANGELOG entry.